### PR TITLE
dependabot springframework update limiter

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 25
+    ignore:
+      - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+        versions: [ "4.x" ]


### PR DESCRIPTION
Limits dependabot from updating springframework to 4.x.x, since we tend to stick to version 3.x.x anyway.

This can be reverted in the future if this fails, or if it is no longer needed.